### PR TITLE
Fix issues in Parser unit tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -42,7 +42,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New game added: %1$s";
     // public static final String MESSAGE_DUPLICATE_PERSON = "This game already exists in the address book";
 
-    private final GameEntry toAdd;
+    public final GameEntry toAdd;
 
     /**
      * Creates an AddCommand to add the specified {@code GameEntry}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -32,8 +32,10 @@ import seedu.address.testutil.GameEntryBuilder;
 
 public class AddCommandParserTest {
 
-    private static final GameEntry GAME_1 = new GameEntry(VALID_GAMETYPE_1.toString(), VALID_STARTAMOUNT_1, VALID_ENDAMOUNT_1,
-            VALID_DATE_1, VALID_DURATION_1, VALID_LOCATION_1.toString(), null);
+
+    private static final GameEntry GAME_1 = new GameEntry(VALID_GAMETYPE_1.toString(), VALID_STARTAMOUNT_1,
+            VALID_ENDAMOUNT_1,VALID_DATE_1,
+            VALID_DURATION_1, VALID_LOCATION_1.toString(), null);
 
     private AddCommandParser parser = new AddCommandParser();
 
@@ -64,7 +66,7 @@ public class AddCommandParserTest {
 
         // multiple date - last date accepted
         assertParseSuccess(parser,  GAMEONE.GAMETYPE_WITH_PREFIX + GAMEONE.STARTAMOUNT_WITH_PREFIX
-                + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMETWO.ENDAMOUNT_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX
+                + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMETWO.DATE_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX
                 + GAMEONE.DURATION_WITH_PREFIX + GAMEONE.LOCATION_WITH_PREFIX
                 + GAMEONE.TAG_WITH_PREFIX, new AddCommand(expectedGameEntry));
 
@@ -84,6 +86,7 @@ public class AddCommandParserTest {
         GameEntry expectedGameEntryMultipleTags = new GameEntryBuilder(GAME_1)
                 .withTags(VALID_TAG_1, VALID_TAG_2)
                 .build();
+
         assertParseSuccess(parser,GAMEONE.GAMETYPE_WITH_PREFIX + GAMEONE.STARTAMOUNT_WITH_PREFIX
                         + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX + GAMEONE.DURATION_WITH_PREFIX
                         + GAMEONE.LOCATION_WITH_PREFIX + GAMEONE.TAG_WITH_PREFIX
@@ -116,7 +119,7 @@ public class AddCommandParserTest {
             // no location
             GameEntry expectedGameEntryNoLocation = new GameEntryBuilder(GAME_1).withLocation("").build();
             assertParseSuccess(parser, GAMEONE.GAMETYPE_WITH_PREFIX + GAMEONE.STARTAMOUNT_WITH_PREFIX
-                    + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX,
+                    + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX + GAMEONE.DURATION_WITH_PREFIX,
                     new AddCommand(expectedGameEntryNoLocation));
         } catch (Exception e) {
             System.out.println(e);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,4 +1,4 @@
-/*
+
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -97,7 +97,7 @@ public class EditCommandParserTest {
                 + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX + GAMEONE.DURATION_WITH_PREFIX
                 + GAMEONE.LOCATION_WITH_PREFIX + GAMEONE.TAG_WITH_PREFIX + GAMETWO.TAG_WITH_PREFIX;
 
-        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withGameType(VALID_GAMETYPE_1)
+        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withGameType(VALID_GAMETYPE_1.toString())
                 .withStartAmount(VALID_STARTAMOUNT_1).withEndAmount(VALID_ENDAMOUNT_1).withDatePlayed(VALID_DATE_1)
                 .withDuration(VALID_DURATION_1).withLocation(VALID_LOCATION_1)
                 .withTags(VALID_TAG_1, VALID_TAG_2).build();
@@ -123,7 +123,7 @@ public class EditCommandParserTest {
         // gameType
         Index targetIndex = INDEX_THIRD_GAMEENTRY;
         String userInput = targetIndex.getOneBased() + GAMEONE.GAMETYPE_WITH_PREFIX;
-        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withGameType(VALID_GAMETYPE_1).build();
+        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withGameType(VALID_GAMETYPE_1.toString()).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -170,10 +170,10 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + GAMETWO.GAMETYPE_WITH_PREFIX + GAMEONE.GAMETYPE_WITH_PREFIX
                 + GAMETWO.STARTAMOUNT_WITH_PREFIX + GAMEONE.STARTAMOUNT_WITH_PREFIX +GAMETWO.ENDAMOUNT_WITH_PREFIX
                 + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMETWO.DATE_WITH_PREFIX + GAMEONE.DATE_WITH_PREFIX
-                + GAMETWO.DURATION_WITH_PREFIX + GAMETWO.DURATION_WITH_PREFIX + GAMETWO.LOCATION_WITH_PREFIX
+                + GAMETWO.DURATION_WITH_PREFIX + GAMEONE.DURATION_WITH_PREFIX + GAMETWO.LOCATION_WITH_PREFIX
                 + GAMEONE.LOCATION_WITH_PREFIX + GAMEONE.TAG_WITH_PREFIX + GAMETWO.TAG_WITH_PREFIX;
 
-        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withGameType(VALID_GAMETYPE_1)
+        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withGameType(VALID_GAMETYPE_1.toString())
                 .withStartAmount(VALID_STARTAMOUNT_1).withEndAmount(VALID_ENDAMOUNT_1)
                 .withDatePlayed(VALID_DATE_1).withDuration(VALID_DURATION_1).withLocation(VALID_LOCATION_1)
                 .withTags(VALID_TAG_1, VALID_TAG_2)
@@ -187,8 +187,8 @@ public class EditCommandParserTest {
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_GAMEENTRY;
-        String userInput = targetIndex.getOneBased() +GAMEONE.STARTAMOUNT_WITH_PREFIX
-                + STARTAMOUNT_INVALID_WITH_PREFIX;
+        String userInput = targetIndex.getOneBased() + STARTAMOUNT_INVALID_WITH_PREFIX
+                + GAMEONE.STARTAMOUNT_WITH_PREFIX;
         EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder().withStartAmount(VALID_STARTAMOUNT_1)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -198,7 +198,7 @@ public class EditCommandParserTest {
         userInput = targetIndex.getOneBased() + GAMEONE.GAMETYPE_WITH_PREFIX + STARTAMOUNT_INVALID_WITH_PREFIX
                 + GAMEONE.ENDAMOUNT_WITH_PREFIX + GAMEONE.STARTAMOUNT_WITH_PREFIX;
         descriptor = new EditGameEntryDescriptorBuilder().withStartAmount(VALID_STARTAMOUNT_1)
-                .withGameType(VALID_GAMETYPE_1).withEndAmount(VALID_ENDAMOUNT_1).build();
+                .withGameType(VALID_GAMETYPE_1.toString()).withEndAmount(VALID_ENDAMOUNT_1).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -214,4 +214,4 @@ public class EditCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 }
-*/
+

--- a/src/test/java/seedu/address/logic/parser/ParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/ParserTestUtil.java
@@ -6,6 +6,7 @@ import seedu.address.model.gameentry.Location;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
@@ -22,16 +23,16 @@ public class ParserTestUtil {
     protected static final GameType VALID_GAMETYPE_1 = new GameType("Poker");
     protected static final Double VALID_STARTAMOUNT_1 = 0.0;
     protected static final Double VALID_ENDAMOUNT_1 = 100.0;
-    protected static DatePlayed VALID_DATE_1;
+    protected static DatePlayed VALID_DATE_1 ;
 
     static {
         try {
-            VALID_DATE_1 = new DatePlayed(new SimpleDateFormat("dd/MM/yy").parse("01/01/21")) ;
+            VALID_DATE_1 = new DatePlayed(new SimpleDateFormat("dd/MM/yy HH:mm").parse( "01/01/21 10:00"));
         } catch (ParseException e) {
             VALID_DATE_1 = null;
+            e.printStackTrace();
         }
     }
-
     protected static final Integer VALID_DURATION_1 = 10;
     protected static final Location VALID_LOCATION_1 = new Location("Sentosa");
     protected static final String VALID_TAG_1 = "lucky";
@@ -39,7 +40,7 @@ public class ParserTestUtil {
 
     protected static final String STARTAMOUNT_INVALID_WITH_PREFIX = " " + PREFIX_STARTAMOUNT + "abc";
     protected static final String ENDAMOUNT_INVALID_WITH_PREFIX = " " + PREFIX_ENDAMOUNT + "abc";
-    protected static final String DATE_INVALID_WITH_PREFIX = " " + PREFIX_DATE + "2021/01/01";
+    protected static final String DATE_INVALID_WITH_PREFIX = " " + PREFIX_DATE + "2021/01 10:00";
     protected static final String DURATION_INVALID_WITH_PREFIX = " " + PREFIX_DURATION + "abc";
 
 
@@ -55,19 +56,19 @@ public class ParserTestUtil {
 
     ParserTestUtil(String gameType, String startAmount, String endAmount, String date, String duration,
                    String location, String tag) {
-        GAMETYPE_WITH_PREFIX =  " "+ PREFIX_GAMETYPE + gameType;
-        STARTAMOUNT_WITH_PREFIX = " " + PREFIX_STARTAMOUNT + startAmount;
-        ENDAMOUNT_WITH_PREFIX = " " + PREFIX_ENDAMOUNT + endAmount;
-        DATE_WITH_PREFIX = " " + PREFIX_DATE + date;
-        DURATION_WITH_PREFIX = " " + PREFIX_DURATION + duration;
-        LOCATION_WITH_PREFIX = " " + PREFIX_LOCATION + location;
-        TAG_WITH_PREFIX = " " + PREFIX_TAG + tag;
+        GAMETYPE_WITH_PREFIX =  " "+ PREFIX_GAMETYPE + " " + gameType;
+        STARTAMOUNT_WITH_PREFIX = " " + PREFIX_STARTAMOUNT  + " " + startAmount;
+        ENDAMOUNT_WITH_PREFIX = " " + PREFIX_ENDAMOUNT  + " " + endAmount;
+        DATE_WITH_PREFIX = " " + PREFIX_DATE + " " + date;
+        DURATION_WITH_PREFIX = " " + PREFIX_DURATION  + duration;
+        LOCATION_WITH_PREFIX = " " + PREFIX_LOCATION + " " + location;
+        TAG_WITH_PREFIX = " " + PREFIX_TAG + " " + tag;
         
     }
     
     protected static final ParserTestUtil GAMEONE = new ParserTestUtil("Poker", "0.0", "100.0",
-            "01/01/21", "10", "Sentosa", "lucky");
+            "01/01/21 10:00", "10", "Sentosa", "lucky");
     protected static final ParserTestUtil GAMETWO = new ParserTestUtil("Black Jack", "10.0",
-            "200.0", "10/10/21", "20", "Marina Bay", "drunk");
+            "200.0", "10/10/21 10:00", "20", "Marina Bay", "drunk");
 
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -22,14 +22,14 @@ public class ParserUtilTest {
 
     private static final String INVALID_STARTAMOUNT = "abc";
     private static final String INVALID_ENDAMOUNT = "abc";
-    private static final String INVALID_DATE = "2021/01/01";
+    private static final String INVALID_DATE = "2021/01/01 10:00";
     private static final String INVALID_DURATION = "abc";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_GAMETYPE = "Poker";
     private static final String VALID_STARTAMOUNT = "0.0";
     private static final String VALID_ENDAMOUNT = "100.0";
-    private static final String VALID_DATE = "01/01/21";
+    private static final String VALID_DATE = "01/01/21 10:00";
     private static final String VALID_DURATION = "10";
     private static final String VALID_LOCATION = "Sentosa";
     private static final String VALID_TAG_1 = "lucky";
@@ -134,14 +134,14 @@ public class ParserUtilTest {
 
     @Test
     public void parseDate_validValueWithoutWhitespace_returnsDate() throws Exception {
-        DatePlayed expectedDate = new DatePlayed(new SimpleDateFormat("dd/MM/yy").parse(VALID_DATE));
+        DatePlayed expectedDate = new DatePlayed(new SimpleDateFormat("dd/MM/yy HH:mm").parse(VALID_DATE));
         assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
     }
 
     @Test
     public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
         String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
-        DatePlayed expectedDate =  new DatePlayed(new SimpleDateFormat("dd/MM/yy").parse(VALID_DATE));
+        DatePlayed expectedDate =  new DatePlayed(new SimpleDateFormat("dd/MM/yy HH:mm").parse(VALID_DATE));
         assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
     }
 

--- a/src/test/java/seedu/address/testutil/GameEntryBuilder.java
+++ b/src/test/java/seedu/address/testutil/GameEntryBuilder.java
@@ -79,6 +79,10 @@ public class GameEntryBuilder {
      * @throws ParseException if the given {@startAmount} is invalid.
      */
     public GameEntryBuilder withStartAmount(String startAmount) {
+        if (startAmount.equals("")) {
+            this.startAmount = 0.0;
+            return this;
+        }
         String trimmedStartAmount = startAmount.trim();
         Double amount;
         try {


### PR DESCRIPTION
Changed date of sample game entry in ParserTestUtil to include time
because equals method in Game Entry always returns false for objects
without specified time.

More test cases should be written for parsing different dates.
Methods in EditGameEntryDescriptor should be change to accept strings.