### PR TITLE
Detect bogus argument flags

### DIFF
--- a/src/main/java/seedu/gamebook/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/gamebook/logic/parser/AddCommandParser.java
@@ -47,7 +47,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                             PREFIX_PROFIT, PREFIX_DURATION, PREFIX_LOCATION, PREFIX_TAG);
 
         } catch (TokenizerException te) {
-            throw new ParseException(ArgumentTokenizer.MESSAGE_DUPLICATE_FLAGS);
+            throw new ParseException(te.getMessage());
         }
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/gamebook/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/gamebook/logic/parser/ArgumentTokenizer.java
@@ -18,6 +18,7 @@ import seedu.gamebook.logic.parser.exceptions.TokenizerException;
 public class ArgumentTokenizer {
 
     public static final String MESSAGE_DUPLICATE_FLAGS = "Duplicate argument flags found.";
+    public static final String MESSAGE_BOGUS_FLAGS = "Unidentified argument flag found: ";
 
     /**
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps prefixes to their
@@ -122,6 +123,8 @@ public class ArgumentTokenizer {
     /**
      * Returns the trimmed value of the argument in the arguments string specified by {@code currentPrefixPosition}.
      * The end position of the value is determined by {@code nextPrefixPosition}.
+     *
+     * @throws TokenizerException If bogus argument flags detected.
      */
     private static String extractArgumentValue(String argsString,
                                         PrefixPosition currentPrefixPosition,
@@ -130,6 +133,10 @@ public class ArgumentTokenizer {
 
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
+
+        if (value.matches("(.* )?/.+")) {
+            throw new TokenizerException(MESSAGE_BOGUS_FLAGS + value.substring(value.lastIndexOf("/")));
+        }
 
         return value.trim();
     }

--- a/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
@@ -65,11 +65,21 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
-    public void tokenize_bogusPrefix_detectsBogus() {
-        String argsString = "  some random string /bogus with leading and trailing spaces ";
+    public void tokenize_invalidPrefix_throwsTokenizerException() {
+        String argsString1 = "some random string /invalid with no prefixes";
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString1));
 
-        // Catches "/bogus"
-        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString));
+        String argsString2 = "preemble /valid value /invalid value";
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString2, new Prefix("/valid")));
+
+        String argsString3 = "preemble /valid /invalid value";
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString3, new Prefix("/valid")));
+
+        String argsString4 = "preemble /valid value /invalid";
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString4, new Prefix("/valid")));
+
+        String argsString5 = "preemble /valid /invalid";
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString5, new Prefix("/valid")));
     }
 
     @Test

--- a/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
@@ -80,6 +80,10 @@ public class ArgumentTokenizerTest {
 
         String argsString5 = "preemble /valid /invalid";
         assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString5, new Prefix("/valid")));
+
+        String argsString6 = "preemble /valid value /invalid value /valid2 value";
+        assertThrows(TokenizerException.class,
+                () -> ArgumentTokenizer.tokenize(argsString6, new Prefix("/valid"), new Prefix("/valid2")));
     }
 
     @Test

--- a/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
@@ -82,8 +82,8 @@ public class ArgumentTokenizerTest {
         assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString5, new Prefix("/valid")));
 
         String argsString6 = "preemble /valid value /invalid value /valid2 value";
-        assertThrows(TokenizerException.class,
-                () -> ArgumentTokenizer.tokenize(argsString6, new Prefix("/valid"), new Prefix("/valid2")));
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString6,
+                new Prefix("/valid"), new Prefix("/valid2")));
     }
 
     @Test

--- a/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/gamebook/logic/parser/ArgumentTokenizerTest.java
@@ -57,12 +57,19 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void tokenize_noPrefixes_allTakenAsPreamble() {
-        String argsString = "  some random string /t tag with leading and trailing spaces ";
+        String argsString = "  some random string with leading and trailing spaces ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
         // Same string expected as preamble, but leading/trailing spaces should be trimmed
         assertPreamblePresent(argMultimap, argsString.trim());
+    }
 
+    @Test
+    public void tokenize_bogusPrefix_detectsBogus() {
+        String argsString = "  some random string /bogus with leading and trailing spaces ";
+
+        // Catches "/bogus"
+        assertThrows(TokenizerException.class, () -> ArgumentTokenizer.tokenize(argsString));
     }
 
     @Test


### PR DESCRIPTION
Parser looks for unknown flags within the parsed value string of provided flags.

The regex looks for unknown flags in the value part of the flag-value pair created by the tokenizer. E.g. using `/g Game /bogus /p 20` and parsing by /g and /p, the pairs are (/g, Game /bogus), and (/p, 20).

It detects either values that start with a / or have at least 1 leading whitespace.

So `/g Game /bogus /p 20` doesn't work
`/g /bogus /p 20` doesn't work
`/g 5/4 Bellagio /p 20` works