### PR TITLE
Add restriction on edit and delete so they can only be used when game list is shown

### DIFF
--- a/src/main/java/seedu/gamebook/logic/Logic.java
+++ b/src/main/java/seedu/gamebook/logic/Logic.java
@@ -16,15 +16,15 @@ import seedu.gamebook.model.gameentry.GameEntry;
 public interface Logic {
 
     /**
-     * Executes the command given the constraint {@param isGameListVisible} and returns the result.
+     * Executes the command given the constraint {@param isGameEntryListVisible} and returns the result.
      *
      * @param commandText       The command as entered by the user.
-     * @param isGameListVisible boolean that is true when game list is displayed.
+     * @param isGameEntryListVisible boolean that is true when game list is displayed.
      * @return the result of the command execution.
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException   If an error occurs during parsing.
      */
-    CommandResult execute(String commandText, boolean isGameListVisible) throws CommandException, ParseException;
+    CommandResult execute(String commandText, boolean isGameEntryListVisible) throws CommandException, ParseException;
 
 
     /**

--- a/src/main/java/seedu/gamebook/logic/Logic.java
+++ b/src/main/java/seedu/gamebook/logic/Logic.java
@@ -16,13 +16,16 @@ import seedu.gamebook.model.gameentry.GameEntry;
 public interface Logic {
 
     /**
-     * Executes the command and returns the result.
-     * @param commandText The command as entered by the user.
+     * Executes the command given the constraint {@param isGameListVisible} and returns the result.
+     *
+     * @param commandText       The command as entered by the user.
+     * @param isGameListVisible boolean that is true when game list is displayed.
      * @return the result of the command execution.
      * @throws CommandException If an error occurs during command execution.
-     * @throws ParseException If an error occurs during parsing.
+     * @throws ParseException   If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText, boolean isGameListVisible) throws CommandException, ParseException;
+
 
     /**
      * Returns the GameBook.
@@ -31,7 +34,9 @@ public interface Logic {
      */
     ReadOnlyGameBook getGameBook();
 
-    /** Returns an unmodifiable view of the filtered list of game entries */
+    /**
+     * Returns an unmodifiable view of the filtered list of game entries
+     */
     ObservableList<GameEntry> getFilteredGameEntryList();
 
     /**

--- a/src/main/java/seedu/gamebook/logic/LogicManager.java
+++ b/src/main/java/seedu/gamebook/logic/LogicManager.java
@@ -38,12 +38,12 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText, boolean isGameListVisible) throws CommandException,
+    public CommandResult execute(String commandText, boolean isGameEntryListVisible) throws CommandException,
         ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = gameBookParser.parseCommand(commandText, isGameListVisible);
+        Command command = gameBookParser.parseCommand(commandText, isGameEntryListVisible);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/gamebook/logic/LogicManager.java
+++ b/src/main/java/seedu/gamebook/logic/LogicManager.java
@@ -38,11 +38,12 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText, boolean isGameListVisible) throws CommandException,
+        ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = gameBookParser.parseCommand(commandText);
+        Command command = gameBookParser.parseCommand(commandText, isGameListVisible);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/gamebook/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/gamebook/logic/commands/DeleteCommand.java
@@ -32,6 +32,10 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_FORMAT + "\n" + COMMAND_SPECIFICATION;
 
     public static final String MESSAGE_DELETE_GAME_ENTRY_SUCCESS = "Deleted game entry: \n%1$s";
+    public static final String COMMAND_NOT_ACCEPTED_WITHOUT_GAME_LIST = "This command can only be used when a game list"
+        + " is shown. Please use \"list\" to show all game entries.";
+    public static final String MESSAGE_FAILURE_WITHOUT_GAME_LIST = COMMAND_FORMAT + "\n"
+        + COMMAND_NOT_ACCEPTED_WITHOUT_GAME_LIST;
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/gamebook/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/gamebook/logic/commands/EditCommand.java
@@ -56,7 +56,10 @@ public class EditCommand extends Command {
         + "Format:\n" + COMMAND_FORMAT + "\n\n"
         + COMMAND_NOTE + "\n\n"
         + "Example:\n" + COMMAND_EXAMPLE;
-
+    public static final String COMMAND_NOT_ACCEPTED_WITHOUT_GAME_LIST = "This command can only be used when a game list"
+        + " is shown. Please use \"list\" to show all game entries.";
+    public static final String MESSAGE_FAILURE_WITHOUT_GAME_LIST = COMMAND_FORMAT + "\n"
+        + COMMAND_NOT_ACCEPTED_WITHOUT_GAME_LIST;
     public static final String MESSAGE_USAGE = COMMAND_FORMAT + "\n" + COMMAND_SPECIFICATION;
     public static final String MESSAGE_EDIT_GAME_SUCCESS = "Edited game entry: \n%1$s\n%2$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/gamebook/logic/parser/GameBookParser.java
+++ b/src/main/java/seedu/gamebook/logic/parser/GameBookParser.java
@@ -43,6 +43,7 @@ public class GameBookParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
@@ -72,6 +73,38 @@ public class GameBookParser {
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
+    }
+
+    /**
+     * Parses user input into command for execution after checking constraints (in this case, if game entry list is
+     * visible).
+     *
+     * @param userInput              full user input string
+     * @param isGameEntryListVisible boolean that shows whether the game list is currently displayed.
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput, boolean isGameEntryListVisible) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HelpCommand.INVALID_COMMAND_MESSAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+
+        //These commands are not accepted when game list is not displayed.
+        if (!isGameEntryListVisible) {
+            if (commandWord.equals(EditCommand.COMMAND_WORD)) {
+                throw new ParseException(EditCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST);
+            }
+            if (commandWord.equals(DeleteCommand.COMMAND_WORD)) {
+                throw new ParseException(DeleteCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST);
+            }
+        }
+
+        return this.parseCommand(userInput);
     }
 
 }

--- a/src/main/java/seedu/gamebook/ui/MainWindow.java
+++ b/src/main/java/seedu/gamebook/ui/MainWindow.java
@@ -225,7 +225,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Executes the command and returns the result.
      *
-     * @see seedu.gamebook.logic.Logic#execute(String)
+     * @see seedu.gamebook.logic.Logic#execute(String, boolean)
      */
     public CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {

--- a/src/main/java/seedu/gamebook/ui/MainWindow.java
+++ b/src/main/java/seedu/gamebook/ui/MainWindow.java
@@ -229,7 +229,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     public CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
-            CommandResult commandResult = logic.execute(commandText);
+            boolean b = gameEntryList.isVisible();
+            CommandResult commandResult = logic.execute(commandText, gameEntryList.isVisible());
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 

--- a/src/test/java/seedu/gamebook/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/gamebook/logic/LogicManagerTest.java
@@ -117,7 +117,7 @@ public class LogicManagerTest {
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
             Model expectedModel) throws CommandException, ParseException {
-        CommandResult result = logic.execute(inputCommand);
+        CommandResult result = logic.execute(inputCommand, true);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);
     }
@@ -157,7 +157,7 @@ public class LogicManagerTest {
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage, Model expectedModel) {
-        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
+        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand, true));
         assertEquals(expectedModel, model);
     }
 

--- a/src/test/java/seedu/gamebook/logic/parser/GameBookParserTest.java
+++ b/src/test/java/seedu/gamebook/logic/parser/GameBookParserTest.java
@@ -128,8 +128,8 @@ public class GameBookParserTest {
     @Test
     public void parseCommand_withGameEntryListNotShown_parseFailureDelete() throws Exception {
         String userInput = DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_GAMEENTRY.getOneBased();
-        assertThrows(ParseException.class, DeleteCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST,
-            () -> parser.parseCommand(userInput, false));
+        String message = DeleteCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST;
+        assertThrows(ParseException.class, message, () -> parser.parseCommand(userInput, false));
     }
 
     @Test
@@ -150,8 +150,8 @@ public class GameBookParserTest {
         String userInput = EditCommand.COMMAND_WORD + " "
             + INDEX_FIRST_GAMEENTRY.getOneBased() + " "
             + GameEntryUtil.getEditGameEntryDescriptorDetails(descriptor);
-        assertThrows(ParseException.class, EditCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST,
-            () -> parser.parseCommand(userInput, false));
+        String message = EditCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST;
+        assertThrows(ParseException.class, message, () -> parser.parseCommand(userInput, false));
     }
 
     @Test
@@ -195,14 +195,12 @@ public class GameBookParserTest {
 
     @Test
     public void parseCommand_unknownCommandWithGameEntryListShown_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
-            () -> parser.parseCommand("unknownCommand", true));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand", true));
     }
 
     @Test
     public void parseCommand_unknownCommandWithGameEntryListNotShown_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
-            () -> parser.parseCommand("unknownCommand", false));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand", false));
     }
 
 }

--- a/src/test/java/seedu/gamebook/logic/parser/GameBookParserTest.java
+++ b/src/test/java/seedu/gamebook/logic/parser/GameBookParserTest.java
@@ -27,6 +27,7 @@ public class GameBookParserTest {
 
     private final GameBookParser parser = new GameBookParser();
 
+    // Tests for parserCommand(String Command)
     @Test
     public void parseCommand_add() throws Exception {
         GameEntry gameEntry = new GameEntryBuilder().build();
@@ -89,4 +90,119 @@ public class GameBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
+
+    // Tests for parserCommand(String Command, boolean isGameEntryListShown)
+    @Test
+    public void parseCommand_withGameEntryListShown_parseSuccessAdd() throws Exception {
+        GameEntry gameEntry = new GameEntryBuilder().build();
+        AddCommand commandAdd = (AddCommand) parser
+            .parseCommand(GameEntryUtil.getAddCommand(gameEntry), true);
+        assertEquals(new AddCommand(gameEntry), commandAdd);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListNotShown_parseSuccessAdd() throws Exception {
+        GameEntry gameEntry = new GameEntryBuilder().build();
+        AddCommand commandAdd = (AddCommand) parser
+            .parseCommand(GameEntryUtil.getAddCommand(gameEntry), false);
+        assertEquals(new AddCommand(gameEntry), commandAdd);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListShown_parseSuccessClear() throws Exception {
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, true) instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListNotShown_parseSuccessClear() throws Exception {
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, false) instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListShown_parseSuccessDelete() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_GAMEENTRY.getOneBased(), true);
+        assertEquals(new DeleteCommand(INDEX_FIRST_GAMEENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListNotShown_parseFailureDelete() throws Exception {
+        String userInput = DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_GAMEENTRY.getOneBased();
+        assertThrows(ParseException.class, DeleteCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST,
+            () -> parser.parseCommand(userInput, false));
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListShown_parseSuccessEdit() throws Exception {
+        GameEntry gameEntry = new GameEntryBuilder().build();
+        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder(gameEntry).build();
+        String userInput = EditCommand.COMMAND_WORD + " "
+            + INDEX_FIRST_GAMEENTRY.getOneBased() + " "
+            + GameEntryUtil.getEditGameEntryDescriptorDetails(descriptor);
+        EditCommand command = (EditCommand) parser.parseCommand(userInput, true);
+        assertEquals(new EditCommand(INDEX_FIRST_GAMEENTRY, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListNotShown_parseFailureEdit() throws Exception {
+        GameEntry gameEntry = new GameEntryBuilder().build();
+        EditGameEntryDescriptor descriptor = new EditGameEntryDescriptorBuilder(gameEntry).build();
+        String userInput = EditCommand.COMMAND_WORD + " "
+            + INDEX_FIRST_GAMEENTRY.getOneBased() + " "
+            + GameEntryUtil.getEditGameEntryDescriptorDetails(descriptor);
+        assertThrows(ParseException.class, EditCommand.MESSAGE_FAILURE_WITHOUT_GAME_LIST,
+            () -> parser.parseCommand(userInput, false));
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListShown_parseSuccessHelp() throws Exception {
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, true) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", true) instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListNotShown_parseSuccessHelp() throws Exception {
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, false) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", false) instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListShown_parseSuccessList() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, true) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3", true) instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_withGameEntryListNotShown_parseSuccessList() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, false) instanceof ListCommand);
+        assertTrue(parser
+            .parseCommand(ListCommand.COMMAND_WORD + " 3", false) instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInputWithGameEntryListShown_throwsParseException() {
+        assertThrows(ParseException.class,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.INVALID_COMMAND_MESSAGE), ()
+                -> parser.parseCommand("", true));
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInputWithGameEntryListNotShown_throwsParseException() {
+        assertThrows(ParseException.class,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.INVALID_COMMAND_MESSAGE), ()
+                -> parser.parseCommand("", false));
+    }
+
+    @Test
+    public void parseCommand_unknownCommandWithGameEntryListShown_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
+            () -> parser.parseCommand("unknownCommand", true));
+    }
+
+    @Test
+    public void parseCommand_unknownCommandWithGameEntryListNotShown_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
+            () -> parser.parseCommand("unknownCommand", false));
+    }
+
 }


### PR DESCRIPTION
Modify logic#execute() to take in a boolean that tells whether GameEntryList is visible. 
GameBookParser will check whether the boolean is true before it parses edit and delete command. 
If the boolean is false and the commandWord is "edit" or "delete", a parseException would be thrown. 
Edit and delete command can only be used when the game list is shown now. 

Still need to double check whether there are parts to change in DG regarding this, and also add test cases. 